### PR TITLE
Allow compilation using new attoparsec and aeson

### DIFF
--- a/ProfilingReport.hs
+++ b/ProfilingReport.hs
@@ -74,8 +74,8 @@ data BriefCostCentre = BriefCostCentre
   } deriving Show
 
 data CostCentre = CostCentre
-  { costCentreName    :: ByteString
-  , costCentreModule  :: ByteString
+  { costCentreName    :: Text
+  , costCentreModule  :: Text
   , costCentreNo      :: Integer
   , costCentreEntries :: Integer
   , individualTime    :: Double
@@ -181,14 +181,15 @@ nestLevel :: Parser Int
 nestLevel = howMany space
 
 costCentre :: Parser CostCentre
-costCentre = CostCentre <$> takeWhile (not . isSpace) <* spaces
-                        <*> takeWhile (not . isSpace) <* spaces
-                        <*> decimal                   <* spaces
-                        <*> decimal                   <* spaces
-                        <*> double                    <* spaces
-                        <*> double                    <* spaces
-                        <*> double                    <* spaces
-                        <*> double
+costCentre =
+    CostCentre <$> (T.decodeUtf8 <$> takeWhile (not . isSpace)) <* spaces
+               <*> (T.decodeUtf8 <$> takeWhile (not . isSpace)) <* spaces
+               <*> decimal                                      <* spaces
+               <*> decimal                                      <* spaces
+               <*> double                                       <* spaces
+               <*> double                                       <* spaces
+               <*> double                                       <* spaces
+               <*> double
 
 type Zipper = TreePos Full
 type Level = Int

--- a/tkyprof.cabal
+++ b/tkyprof.cabal
@@ -56,9 +56,10 @@ executable tkyprof
   hs-source-dirs:     ., config, bin
   other-modules:      Paths_tkyprof
   ghc-options:        -Wall -threaded
+  extensions:         TemplateHaskell
   build-depends:      base >= 4 && < 5
-                    , aeson >= 0.3 && < 0.7
-                    , attoparsec >= 0.9 && < 0.11
+                    , aeson >= 0.3 && < 0.8
+                    , attoparsec >= 0.9 && < 0.12
                     , attoparsec-conduit >= 1.0 && < 1.1
                     , bytestring >= 0.9 && < 0.11
                     , cmdargs >= 0.7 && < 0.11


### PR DESCRIPTION
Great tool man!

I changed the type for names/modules to `Text` since `aeson >= 0.7` dropped the `ToJSON`/`FromJSON` instances for `ByteString`.

Additionally I added `TemplateHaskell` in the cabal file. This allows compilation when you have profiling enabled for all executables and libraries (see https://ghc.haskell.org/trac/ghc/ticket/8443).
